### PR TITLE
added ohm-js to the dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "babel-runtime": "6.x.x",
     "clj-fuzzy": "^0.3.2",
-    "its-set": "^1.1.5"
+    "its-set": "^1.1.5",
+    "ohm-js": "^0.13.1"
   }
 }


### PR DESCRIPTION
Should fix [issue 13](https://github.com/finnfiddle/words-to-numbers/issues/13) - (missing package.json library).