### PR TITLE
Update ohm-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "babel-runtime": "6.x.x",
     "clj-fuzzy": "^0.3.2",
     "its-set": "^1.1.5",
-    "ohm-js": "^0.13.1"
+    "ohm-js": "^0.14.0"
   }
 }


### PR DESCRIPTION
Installing the older version of ohm-js as a dependency breaks on environments without bash. This new version should fix that issue.