### PR TITLE
option to preserve ordinal suffixes

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -303,6 +303,22 @@ it('seventeen dot two four dot twelve dot five', () => {
   expect(wtn('seventeen dot two four dot twelve dot five')).to.eq('17.24 dot 12.5');
 });
 
+it('second', () => {
+  expect(wtn('second', { preserveOrdinals: true })).to.eq('2nd');
+});
+
+it('one hundred thirty third', () => {
+  expect(wtn('one hundred thirty third', { preserveOrdinals: true })).to.eq('133rd');
+});
+
+it('the eleventh hour', () => {
+  expect(wtn('the eleventh hour', { preserveOrdinals: true })).to.eq('the 11th hour');
+});
+
+it('first four', () => {
+  expect(wtn('first four', { preserveOrdinals: true })).to.eq('1st 4');
+});
+
 // these dont work below fml
 
 // it('one thirty thousand', () => {

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1,7 +1,7 @@
 import { splice } from './util';
-import { TOKEN_TYPE, NUMBER } from './constants';
+import { TOKEN_TYPE, NUMBER, ORDINAL_SUFFIXES } from './constants';
 
-const getNumber = region => {
+const getNumber = (region, options) => {
   let sum = 0;
   let decimalReached = false;
   let decimalUnits = [];
@@ -67,23 +67,33 @@ const getNumber = region => {
     });
   });
 
+  if (options.preserveOrdinals) {
+    sum += getOrdinalSuffix(region);
+  }
+
   return sum;
 };
 
-const replaceRegionsInText = (regions, text) => {
+const getOrdinalSuffix = region => {
+  const token = region.tokens[region.tokens.length - 1].lowerCaseValue;
+  const suffix = token.substring(token.length - 2);
+  return ORDINAL_SUFFIXES.includes(suffix) ? suffix : '';
+};
+
+const replaceRegionsInText = (regions, text, options) => {
   let replaced = text;
   let offset = 0;
   regions.forEach(region => {
     const length = region.end - region.start + 1;
-    const replaceWith = `${getNumber(region)}`;
+    const replaceWith = `${getNumber(region, options)}`;
     replaced = splice(replaced, region.start + offset, length, replaceWith);
     offset -= length - replaceWith.length;
   });
   return replaced;
 };
 
-export default ({ regions, text }) => {
+export default ({ regions, text, options }) => {
   if (!regions) return text;
-  if (regions[0].end - regions[0].start === text.length - 1) return getNumber(regions[0]);
-  return replaceRegionsInText(regions, text);
+  if (regions[0].end - regions[0].start === text.length - 1) return getNumber(regions[0], options);
+  return replaceRegionsInText(regions, text, options);
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -114,6 +114,13 @@ export const PUNCTUATION = [
   ' ',
 ];
 
+export const ORDINAL_SUFFIXES = [
+  'st',
+  'nd',
+  'rd',
+  'th'
+];
+
 export const TOKEN_TYPE = {
   UNIT: 0,
   TEN: 1,

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import compiler from './compiler';
 export function wordsToNumbers (text, options = {}) {
   const regions = parser(text, options);
   if (!regions.length) return text;
-  const compiled = compiler({ text, regions });
+  const compiled = compiler({ text, regions, options });
   return compiled;
 }
 


### PR DESCRIPTION
By default, `wordsToNumbers` converts ordinal number words to plain numbers:
```
wordsToNumbers('One Hundred Sixteenth Congress'); // 116 Congress
```
This PR adds an option `preserveOrdinals` to retain the ordinal suffixes, which can be useful for preserving semantic meaning within longer strings:
```
wordsToNumbers('One Hundred Sixteenth Congress', { preserveOrdinals: true }); // 116th Congress
```
Thanks for your work on this library!